### PR TITLE
Timeout increase

### DIFF
--- a/lib/aquatone/collectors/wayback_machine.rb
+++ b/lib/aquatone/collectors/wayback_machine.rb
@@ -12,7 +12,7 @@ module Aquatone
         }
       }
 
-      DEFAULT_TIMEOUT = 30.freeze
+      DEFAULT_TIMEOUT = 600.freeze
 
       def run
         response = nil


### PR DESCRIPTION
Increase the timeout because during some tests ons some domainnames raises a timeout error.